### PR TITLE
Add mobile layout for character rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,21 @@
   .remove{ padding:8px 10px; }
   .small{ font-size:12px; color:#555 }
 
+  @media (max-width:480px){
+    .row{
+      grid-template-columns:auto 1fr;
+      grid-template-areas:
+        "check name"
+        "label weight"
+        ". remove";
+    }
+    .row input[type="checkbox"]{ grid-area:check; }
+    .row .small{ grid-area:label; }
+    .row .name{ grid-area:name; grid-column:span 2; min-width:0; }
+    .row .weight{ grid-area:weight; }
+    .row .remove{ grid-area:remove; }
+  }
+
   .wheel-wrap{ display:flex; flex-direction:column; align-items:center; gap:10px; }
   .spacer{ height:8px; }
   .announce{


### PR DESCRIPTION
## Summary
- add mobile media query to show character rows in two-column layout
- move weight input and delete button beneath name input for narrow screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c590071d8883219b535aa33128b393