### PR TITLE
fix: guard service worker caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -23,7 +23,11 @@ self.addEventListener('fetch', (e) => {
   e.respondWith(
     caches.match(e.request).then(r => r || fetch(e.request).then(resp => {
       const url = new URL(e.request.url);
-      if (url.origin === location.origin) {
+      if (
+        e.request.method === 'GET' &&
+        resp.ok &&
+        url.origin === location.origin
+      ) {
         const respClone = resp.clone();
         caches.open(CACHE).then(c => c.put(e.request, respClone));
       }


### PR DESCRIPTION
## Summary
- avoid caching non-GET or failed requests

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f94504c83218af0271528223179