### PR TITLE
Ensure character rows stay on one line on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,13 @@
   .name{ width:100%; min-width:0; padding:8px 10px; border:1px solid #bbb; border-radius:8px; }
   .weight{ width:100%; min-width:0; padding:8px 10px; border:1px solid #bbb; border-radius:8px; text-align:right; }
   .remove{ width:100%; padding:8px 10px; }
+
+  @media (max-width:480px){
+    .row{ display:flex; }
+    .row > .name{ flex:1 1 auto; width:auto; }
+    .row > .weight{ flex:0 0 60px; width:60px; }
+    .row > .remove{ flex:0 0 auto; width:auto; }
+  }
   .small{ font-size:12px; color:#555 }
 
   .wheel-wrap{ display:flex; flex-direction:column; align-items:center; gap:10px; }


### PR DESCRIPTION
## Summary
- keep character name, weight and delete button in one line on small screens by switching to flex layout under 480px width

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68c596ff9cec83218dfab32a8c386abe