### PR TITLE
Allow direct weight input and default to 1 when empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,10 +89,10 @@
         </div>
         <div class="btns">
           <input id="newName" class="name" placeholder="新しいキャラ名" />
-          <input id="newWeight" class="weight" type="number" min="0.1" max="10" step="0.1" value="1" inputmode="decimal" />
+          <input id="newWeight" class="weight" type="number" min="0.1" max="10" step="any" value="1" inputmode="decimal" />
           <button id="add">追加</button>
         </div>
-        <div class="small">※重みは 0.1〜10（0.1刻み）。名称は重複可ですが、同名の別キャラを分けたい場合は表記を変えてください。</div>
+        <div class="small">※重みは 0.1〜10。未入力の場合は1になります。名称は重複可ですが、同名の別キャラを分けたい場合は表記を変えてください。</div>
       </div>
 
       <div class="panel">
@@ -249,8 +249,8 @@
       cb.addEventListener('change',()=>{ state.on[name]=cb.checked; ui.toggleStart(); wheel.rebuild(); });
       const nameInput = document.createElement('input'); nameInput.className='name'; nameInput.value=name;
       nameInput.addEventListener('change',()=>renameCharacter(name, nameInput.value));
-      const w = document.createElement('input'); w.className='weight'; w.type='number'; w.min=0.1; w.max=10; w.step=0.1; w.value=state.weight[name]; w.inputMode='decimal'; w.setAttribute('aria-label','重み'); w.title='重み';
-      w.addEventListener('input',()=>{ let v=parseFloat(w.value); if(isNaN(v)||v<0.1) v=0.1; if(v>10) v=10; v=Math.round(v*10)/10; state.weight[name]=v; w.value=v; wheel.rebuild(); });
+      const w = document.createElement('input'); w.className='weight'; w.type='number'; w.min=0.1; w.max=10; w.step='any'; w.value=state.weight[name]; w.inputMode='decimal'; w.setAttribute('aria-label','重み'); w.title='重み';
+      w.addEventListener('input',()=>{ let v=parseFloat(w.value); if(isNaN(v)) v=1; if(v<0.1) v=0.1; if(v>10) v=10; state.weight[name]=v; w.value=v; wheel.rebuild(); });
       const del = document.createElement('button'); del.className='remove'; del.textContent='削除';
       del.addEventListener('click',()=>removeCharacter(name));
       row.append(cb, nameInput, w, del);
@@ -273,7 +273,7 @@
   }
   refs.add.addEventListener('click',()=>{
     const name = (refs.newName.value||'').trim(); if(!name) return;
-    let v = parseFloat(refs.newWeight.value); if(isNaN(v)||v<0.1) v=0.1; if(v>10) v=10; v=Math.round(v*10)/10;
+    let v = parseFloat(refs.newWeight.value); if(isNaN(v)) v=1; if(v<0.1) v=0.1; if(v>10) v=10;
     state.names.push(name); state.on[name]=true; state.weight[name]=v;
     refs.newName.value=''; refs.newWeight.value='1';
     wheel.rebuild(); renderChecks();


### PR DESCRIPTION
## Summary
- Allow free weight entry without 0.1 increments
- Default weight to 1 when input is left blank and update help text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a12fffc8321b6484ce511c7fe0b