### PR TITLE
Adjust preset radio selection on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,34 @@
     return num;
   }
 
+  function findMatchingPresetKey(names, on, weight){
+    for (const [key, list] of Object.entries(PRESETS)){
+      if (list.length !== names.length) continue;
+      let matched = true;
+      for (let i = 0; i < list.length; i++){
+        if (list[i] !== names[i]){ matched = false; break; }
+      }
+      if (!matched) continue;
+      for (const name of list){
+        if (!on[name]){ matched = false; break; }
+        const w = normalizeWeightValue(weight[name]);
+        if (w !== 1){ matched = false; break; }
+      }
+      if (matched) return key;
+    }
+    return null;
+  }
+
+  function selectPresetRadio(value){
+    const radios = document.querySelectorAll('#presets input[name="preset"]');
+    for (const radio of radios){
+      if (radio.value === value){
+        radio.checked = true;
+        break;
+      }
+    }
+  }
+
   function saveStateToCookie(){
     try {
       const data = {
@@ -211,6 +239,8 @@
       state.names = names;
       state.on = on;
       state.weight = weight;
+      const matchedPreset = findMatchingPresetKey(state.names, state.on, state.weight);
+      if (matchedPreset){ selectPresetRadio(matchedPreset); }
       return true;
     } catch (err) {
       console.error('状態の読み込みに失敗しました', err);
@@ -481,13 +511,11 @@
   function init(){
     const loaded = loadStateFromCookie();
     if (loaded){
-      document.querySelectorAll('#presets input[name="preset"]').forEach(r => { r.checked = false; });
       renderChecks();
       wheel.rebuild();
       ui.toggleStart();
     } else {
-      const oratanRadio = document.querySelector('#presets input[value="オラタン"]');
-      if (oratanRadio){ oratanRadio.checked = true; }
+      selectPresetRadio('オラタン');
       applyPreset('オラタン');
     }
     queueSaveStateToCookie();


### PR DESCRIPTION
## Summary
- add helpers to detect whether the saved state matches a predefined preset and select the corresponding radio input
- update cookie loading to keep preset radios in sync with saved data while removing the blanket uncheck in init
- retain the Oratan preset as the default selection when no saved state is found

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97fca16608321ac69a5d2a24a0384