### PR TITLE
Rename weight input element for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,12 +349,12 @@
         cb.addEventListener('change',()=>{ state.on[name]=cb.checked; ui.toggleStart(); wheel.rebuild(); queueSaveStateToCookie(); });
         const nameInput = document.createElement('input'); nameInput.className='name'; nameInput.value=name;
         nameInput.addEventListener('change',()=>{ if(renameCharacter(name, nameInput.value)){ queueSaveStateToCookie(); } });
-        const w = document.createElement('input'); w.className='weight'; w.type='number'; w.min=0.1; w.max=10; w.step='any'; w.value=state.weight[name]; w.inputMode='decimal'; w.setAttribute('aria-label','重み'); w.title='重み';
-        w.addEventListener('input',()=>{ let v=parseFloat(w.value); if(isNaN(v)) v=1; if(v<0.1) v=0.1; if(v>10) v=10; state.weight[name]=v; w.value=v; wheel.rebuild(); });
-        w.addEventListener('change',()=>{ queueSaveStateToCookie(); });
+        const weightInput = document.createElement('input'); weightInput.className='weight'; weightInput.type='number'; weightInput.min=0.1; weightInput.max=10; weightInput.step='any'; weightInput.value=state.weight[name]; weightInput.inputMode='decimal'; weightInput.setAttribute('aria-label','重み'); weightInput.title='重み';
+        weightInput.addEventListener('input',()=>{ let v=parseFloat(weightInput.value); if(isNaN(v)) v=1; if(v<0.1) v=0.1; if(v>10) v=10; state.weight[name]=v; weightInput.value=v; wheel.rebuild(); });
+        weightInput.addEventListener('change',()=>{ queueSaveStateToCookie(); });
         const del = document.createElement('button'); del.className='remove'; del.textContent='削除';
         del.addEventListener('click',()=>{ if(removeCharacter(name)){ queueSaveStateToCookie(); } });
-        row.append(cb, nameInput, w, del);
+        row.append(cb, nameInput, weightInput, del);
         refs.checks.appendChild(row);
       }
       ui.toggleStart();


### PR DESCRIPTION
## Summary
- rename the temporary weight input element in renderChecks to `weightInput`
- update all references within the function to use the clearer name and avoid confusion with weight values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9863886848321ab21e434002939c5