### PR TITLE
Add favorite slots for character configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,16 @@
     .row > .remove{ flex:0 0 auto; width:auto; }
   }
   .small{ font-size:12px; color:#555 }
+  .preset-row{ display:flex; flex-wrap:wrap; gap:12px; margin:8px 0 10px 0; align-items:flex-start; }
+  .preset-row > .preset-block{ flex:1 1 240px; }
+  .preset-row > .favorite-block{ flex:1 1 220px; }
+  .preset-block{ display:grid; gap:6px; }
+  .favorite-block{ display:flex; flex-direction:column; gap:6px; padding:8px; border:1px solid #ccc; border-radius:8px; background:#fff; }
+  .favorite-mode{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
+  .favorite-buttons{ display:flex; gap:8px; }
+  .favorite-buttons button{ flex:1 1 0; min-width:44px; }
+  .favorite-buttons button.saved{ background:#fff3c4; border-color:#d6a000; font-weight:600; color:#7a5600; }
+  .favorite-status{ min-height:1.2em; color:#555; }
 
   .wheel-wrap{ display:flex; flex-direction:column; align-items:center; gap:10px; }
   .spacer{ height:8px; }
@@ -74,12 +84,27 @@
     <div class="grid">
       <div class="panel">
         <strong>キャラクター編集</strong>
-        <div id="presets" class="small" style="display:grid; gap:6px; margin:8px 0 10px 0;">
-          <div><strong>プリセット：</strong></div>
-          <label><input type="radio" name="preset" value="OMG"> OMG</label>
-          <label><input type="radio" name="preset" value="オラタン" checked> オラタン</label>
-          <label><input type="radio" name="preset" value="フォース"> フォース</label>
-          <label><input type="radio" name="preset" value="禁書VO"> 禁書VO</label>
+        <div class="preset-row">
+          <div id="presets" class="small preset-block">
+            <div><strong>プリセット：</strong></div>
+            <label><input type="radio" name="preset" value="OMG"> OMG</label>
+            <label><input type="radio" name="preset" value="オラタン" checked> オラタン</label>
+            <label><input type="radio" name="preset" value="フォース"> フォース</label>
+            <label><input type="radio" name="preset" value="禁書VO"> 禁書VO</label>
+          </div>
+          <div id="favorites" class="small favorite-block" aria-label="お気に入りスロット">
+            <div><strong>お気に入り：</strong></div>
+            <div class="favorite-mode">
+              <label><input type="radio" name="favoriteMode" value="load" checked> 読込</label>
+              <label><input type="radio" name="favoriteMode" value="save"> 保存</label>
+            </div>
+            <div class="favorite-buttons">
+              <button type="button" data-favorite-slot="0">1</button>
+              <button type="button" data-favorite-slot="1">2</button>
+              <button type="button" data-favorite-slot="2">3</button>
+            </div>
+            <div class="favorite-status" data-favorite-status aria-live="polite"></div>
+          </div>
         </div>
         <div id="checks" class="checkwrap" aria-label="キャラクター編集リスト"></div>
         <div class="btns">

--- a/js/main.js
+++ b/js/main.js
@@ -42,6 +42,7 @@ function init() {
     wheel: /** @type {HTMLCanvasElement} */ ($('#wheel')),
     current: /** @type {HTMLElement} */ ($('#current')),
     presets: /** @type {HTMLElement} */ ($('#presets')),
+    favorites: /** @type {HTMLElement} */ ($('#favorites')),
     maxTime: /** @type {HTMLInputElement} */ ($('#maxTime')),
     decelTime: /** @type {HTMLInputElement} */ ($('#decelTime'))
   };
@@ -76,12 +77,14 @@ function init() {
       start: refs.start,
       stop: refs.stop,
       current: refs.current,
-      presets: refs.presets
+      presets: refs.presets,
+      favorites: refs.favorites
     },
     { wheel, animation }
   );
   ui.init();
   ui.setStopButtonEnabled(false);
+  ui.refreshFavoriteButtons();
 
   const startHandler = (event) => {
     event.preventDefault();
@@ -133,6 +136,7 @@ function init() {
     }
   }
 
+  ui.refreshFavoriteButtons();
   queueSaveStateToCookie();
   window.requestAnimationFrame(() => wheel.resize());
 }


### PR DESCRIPTION
## Summary
- add a preset-adjacent favourites panel with save/load mode toggles and three slots
- persist favourite snapshots alongside the main state cookie and expose helpers to manage them
- wire the UI to update favourite indicators, trigger saves/loads, and ensure the roulette uses stored favourites on startup

## Testing
- node --check js/state.js
- node --check js/ui.js
- node --check js/main.js

------
https://chatgpt.com/codex/tasks/task_e_68cb83768078832194082cdec4050231