### PR TITLE
Ensure favorite slot buttons are visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,13 @@
   .preset-block{ display:grid; gap:6px; }
   .favorite-block{ display:flex; flex-direction:column; gap:6px; padding:8px; border:1px solid #ccc; border-radius:8px; background:#fff; }
   .favorite-mode{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
-  .favorite-buttons{ display:flex; gap:8px; }
-  .favorite-buttons button{ flex:1 1 0; min-width:44px; }
+  .favorite-buttons{
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(96px, 1fr));
+    gap:8px;
+    width:min(100%, calc(100vw - 64px));
+  }
+  .favorite-buttons button{ width:100%; min-width:0; }
   .favorite-buttons button.saved{ background:#fff3c4; border-color:#d6a000; font-weight:600; color:#7a5600; }
   .favorite-status{ min-height:1.2em; color:#555; }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -16,7 +16,8 @@ import {
   findMatchingPresetKey,
   saveFavorite,
   loadFavorite,
-  hasFavorite
+  hasFavorite,
+  FAVORITE_SLOT_COUNT
 } from './state.js';
 
 /**
@@ -67,7 +68,12 @@ export class CharacterListUI {
   /** お気に入りボタン関連の初期化 */
   setupFavoriteControls() {
     const container = this.refs.favorites;
-    this.favoriteButtons = Array.from(container.querySelectorAll('button[data-favorite-slot]'));
+    const buttonsContainer = container.querySelector('.favorite-buttons');
+    if (!buttonsContainer) {
+      throw new Error('Favorite buttons container not found.');
+    }
+    this.ensureFavoriteButtonSlots(buttonsContainer);
+    this.favoriteButtons = Array.from(buttonsContainer.querySelectorAll('button[data-favorite-slot]'));
     this.favoriteModeInputs = Array.from(container.querySelectorAll('input[name="favoriteMode"]'));
     this.favoriteStatusEl = container.querySelector('[data-favorite-status]');
     this.favoriteButtons.forEach((button) => {
@@ -89,6 +95,36 @@ export class CharacterListUI {
     });
     this.refreshFavoriteButtons();
     this.setFavoriteStatus('');
+  }
+
+  /**
+   * HTMLに存在するお気に入りボタン数をスロット数と同期する。
+   * @param {Element} buttonsContainer ボタンを内包する要素。
+   */
+  ensureFavoriteButtonSlots(buttonsContainer) {
+    const buttons = Array.from(buttonsContainer.querySelectorAll('button[data-favorite-slot]'));
+    // 余分なボタンは削除する
+    for (let i = buttons.length - 1; i >= FAVORITE_SLOT_COUNT; i -= 1) {
+      buttons[i].remove();
+    }
+    // 残ったボタンの番号と表示を整える
+    const syncedButtons = Array.from(buttonsContainer.querySelectorAll('button[data-favorite-slot]'));
+    syncedButtons.forEach((button, index) => {
+      const displayIndex = index + 1;
+      button.dataset.favoriteSlot = String(index);
+      button.textContent = String(displayIndex);
+      button.setAttribute('aria-label', `お気に入り${displayIndex}`);
+    });
+    // 足りない分を追加する
+    for (let i = syncedButtons.length; i < FAVORITE_SLOT_COUNT; i += 1) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.favoriteSlot = String(i);
+      const displayIndex = i + 1;
+      button.textContent = String(displayIndex);
+      button.setAttribute('aria-label', `お気に入り${displayIndex}`);
+      buttonsContainer.appendChild(button);
+    }
   }
 
   /** 現在のモードを取得する */


### PR DESCRIPTION
## Summary
- update the favorite button container to use a wrapping grid layout with a responsive width limit so additional slots stay within the viewport
- synchronize the rendered favorite buttons with the configured slot count and add accessible labels so new slots appear automatically

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc9bcafe648321a1ba042b038ed700