### PR TITLE
Orient roulette labels radially

### DIFF
--- a/js/wheel.js
+++ b/js/wheel.js
@@ -160,7 +160,6 @@ export class WheelRenderer {
         if (scale < 1) {
           ctx.scale(scale, scale);
         }
-        ctx.rotate(-mid);
         ctx.fillText(label, 0, 0);
         ctx.restore();
       }


### PR DESCRIPTION
## Summary
- rotate roulette segment labels along their segment angles so they radiate from the center

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf7de7fe48321ab8c8827af835e3b